### PR TITLE
fixed bug when passing in empty list to createFormList.

### DIFF
--- a/index.js
+++ b/index.js
@@ -75,19 +75,17 @@ function createFormList (forms, options, callback) {
 
   async.map(streams, parse, function buildXml (err, results) {
     if (err) return callback(err)
-
     var xml = builder.create({
       xforms: {
         '@xmlns': 'http://openrosa.org/xforms/xformsList',
-        '#list': results
       }
     }, {
       encoding: 'UTF-8'
-    }).end({
-      pretty: true
     })
-
-    callback(null, xml)
+    if (results && results.length > 0) {
+        xml.ele({'#list': results})
+    }
+    callback(null, xml.end({pretty: true}))
   })
 
   function parse (xformStream, callback) {

--- a/test/test.js
+++ b/test/test.js
@@ -2,6 +2,7 @@ var test = require('tape')
 var fs = require('fs')
 var resumer = require('resumer')
 var request = require('request')
+var expat = require('node-expat')
 var createFormList = require('../')
 
 var forms = [
@@ -77,6 +78,17 @@ test('Accepts an array of streams from strings', function (t) {
   createFormList(formStreams, function (err, result) {
     t.error(err, 'Does not produce error')
     t.equal(result, expectedXml, 'Matches expected xml FormList')
+    t.end()
+  })
+})
+
+test('Empty forms parameter returns parseable XML', function(t) {
+  createFormList([], function (err, result) {
+    var parser = new expat.Parser('UTF-8')
+    t.error(err, 'Does not produce error')
+    t.doesNotThrow(function() {
+      parser.write(result)
+    });
     t.end()
   })
 })


### PR DESCRIPTION
ODK Collect gives an error when there are no forms.  Because openrosa-formlist returns invalid xml `<#list/>`:

```
<?xml version="1.0" encoding="UTF-8"?>
<xforms xmlns="http://openrosa.org/xforms/xformsList">
  <#list/>
</xforms>
```

See also: https://github.com/medic/medic-webapp/issues/886#issuecomment-110361466

Added a test here, not sure if this is too broad because I'm invoking the parser, but have a look.  Might be best to just do a string compare.  We want this instead:

```
<?xml version="1.0" encoding="UTF-8"?>
<xforms xmlns="http://openrosa.org/xforms/xformsList"/>
```
